### PR TITLE
Fix compile with lovr and luajit (kludge)

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1304,7 +1304,10 @@ static int json_decode(lua_State *l)
 
 /* ===== INITIALISATION ===== */
 
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 502
+// Awkward: If you're using Lua 5.2, it will nicely define LUA_VERSION_NUM=502.
+// But if you're using lauxlib.h from LuaJIT, it defines LUA_VERSION_NUM=501
+// despite implementing some Lua 5.2 functions. As a kludge, we check for another 5.2 symbol it defines:
+#if !defined(luaL_setfuncs) && (!defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 502)
 /* Compatibility for Lua 5.1.
  *
  * luaL_setfuncs() is used to create a module table where the functions have


### PR DESCRIPTION
Awkward: If you're using Lua 5.2, it will nicely define LUA_VERSION_NUM=502. But if you're using lauxlib.h from LuaJIT, it defines LUA_VERSION_NUM=501 despite implementing some Lua 5.2 functions. This means a preprocessor check intended to detect Vanilla Lua 5.1 misfires, and cjson fails to build with a duplicate symbol error. To fix this, we augment the check for another, unrelated 5.2 symbol LuaJIT incidentally defines in the preprocessor.

Not sure about this but can't think of a better way to do it.